### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/arm-pr.yml
+++ b/.github/workflows/arm-pr.yml
@@ -6,6 +6,9 @@ name: Dev build (ARM PR artifacts)
 on:
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
     windows-arm64:
         runs-on: windows-11-arm


### PR DESCRIPTION
Potential fix for [https://github.com/Horuse/Splitwave/security/code-scanning/4](https://github.com/Horuse/Splitwave/security/code-scanning/4)

Add an explicit top-level `permissions` block in `.github/workflows/arm-pr.yml` so all jobs inherit least-privilege token access.  
Best single fix without changing functionality:

- Insert at workflow root (after `on:` block, before `jobs:`):
  - `permissions:`
  - `contents: read`

Why this works:
- `actions/checkout` needs `contents: read`.
- This workflow does not create releases, comments, or modify PRs/issues, so broader write permissions are unnecessary.
- `actions/upload-artifact` does not require repository write scopes via `GITHUB_TOKEN` for this usage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
