### PR TITLE
feat: pre-release update channel, safe mode crash protection, and pipeline backup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
                   tagName: ${{ github.ref_name }}
                   releaseName: Splitwave ${{ github.ref_name }}
                   releaseDraft: true
-                  prerelease: false
+                  prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}
                   args: ${{ matrix.args }}
 
     linux:
@@ -106,7 +106,7 @@ jobs:
                   tagName: ${{ github.ref_name }}
                   releaseName: Splitwave ${{ github.ref_name }}
                   releaseDraft: true
-                  prerelease: false
+                  prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}
                   args: --bundles appimage,deb,rpm
 
             # linuxdeploy bundles libwayland/libpipewire/libspa; on newer Mesa they
@@ -211,5 +211,5 @@ jobs:
                   tagName: ${{ github.ref_name }}
                   releaseName: Splitwave ${{ github.ref_name }}
                   releaseDraft: true
-                  prerelease: false
+                  prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}
                   args: --bundles nsis

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6284,6 +6284,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ts-rs",
+ "url",
  "vst3",
  "webpki-roots 0.26.11",
  "webrtc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,6 +70,7 @@ tauri-plugin-os = "2"
 tauri-plugin-autostart = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+url = "2"
 thiserror = "1"
 cpal = "0.15"
 rtrb = "0.3"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -533,8 +533,8 @@ pub async fn stop_pipeline(state: State<'_, AppState>, app: AppHandle) -> AppRes
 
 // Updater errors serialize Display-only, hiding reqwest's cause; unwind source()+Debug.
 #[tauri::command]
-pub async fn diagnose_update_error(app: AppHandle) -> String {
-    let report = match configured_updater(&app) {
+pub async fn diagnose_update_error(app: AppHandle, endpoint: Option<String>) -> String {
+    let report = match configured_updater(&app, endpoint.as_deref()) {
         Ok(updater) => match updater.check().await {
             Ok(Some(u)) => format!("check succeeded; update {} is available", u.version),
             Ok(None) => "check succeeded; no update available".to_string(),
@@ -563,14 +563,21 @@ fn updater_tls_config() -> rustls::ClientConfig {
         .with_no_client_auth()
 }
 
-fn configured_updater(app: &AppHandle) -> Result<tauri_plugin_updater::Updater, String> {
+fn configured_updater(
+    app: &AppHandle,
+    endpoint: Option<&str>,
+) -> Result<tauri_plugin_updater::Updater, String> {
     use tauri_plugin_updater::UpdaterExt;
     #[cfg(target_os = "linux")]
-    let builder = app
+    let mut builder = app
         .updater_builder()
         .configure_client(|b| b.tls_backend_preconfigured(updater_tls_config()));
     #[cfg(not(target_os = "linux"))]
-    let builder = app.updater_builder();
+    let mut builder = app.updater_builder();
+    if let Some(ep) = endpoint {
+        let url = url::Url::parse(ep).map_err(|e| e.to_string())?;
+        builder = builder.endpoints(vec![url]).map_err(|e| e.to_string())?;
+    }
     builder.build().map_err(|e| e.to_string())
 }
 
@@ -588,9 +595,12 @@ pub struct UpdateMetadata {
 /// Mirrors `plugin:updater|check` but with bundled roots wired into the HTTP
 /// client; the plugin's own `check` command can't be configured.
 #[tauri::command]
-pub async fn check_for_updates(app: AppHandle) -> Result<Option<UpdateMetadata>, String> {
+pub async fn check_for_updates(
+    app: AppHandle,
+    endpoint: Option<String>,
+) -> Result<Option<UpdateMetadata>, String> {
     use tauri::Manager;
-    let updater = configured_updater(&app)?;
+    let updater = configured_updater(&app, endpoint.as_deref())?;
     let Some(update) = updater.check().await.map_err(|e| e.to_string())? else {
         return Ok(None);
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -259,6 +259,17 @@ pub fn run() {
                 }
             }
 
+            if let Ok(dir) = handle.path().app_data_dir() {
+                let current = dir.join("pipelines.json");
+                let backup = dir.join("pipelines.backup-v1.json");
+                if current.exists() && !backup.exists() {
+                    if let Ok(bytes) = std::fs::read(&current) {
+                        let _ = std::fs::write(&backup, bytes);
+                        info!(path = %backup.display(), "created automatic pre-1.2.0 pipeline backup");
+                    }
+                }
+            }
+
             #[cfg(target_os = "linux")]
             if let Err(error) = audio::virtual_device::restore(&handle) {
                 tracing::error!(%error, "failed to restore PipeWire virtual devices");

--- a/src/lib/components/layout/header.svelte
+++ b/src/lib/components/layout/header.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import { slide } from 'svelte/transition';
 	import { themeStore } from '$lib/modules/theme/stores';
 	import { platform } from '@tauri-apps/plugin-os';
 	import { getCurrentWindow } from '@tauri-apps/api/window';
@@ -7,6 +8,7 @@
 	import { AboutModal } from '$lib/modules/about/ui';
 	import { checkForUpdates } from '$lib/modules/updater';
 	import { pipelineStore } from '$lib/modules/pipeline/stores.svelte';
+	import { audioStore } from '$lib/modules/audio/stores.svelte';
 	import { Popover } from '$lib/modules/overlay/ui';
 
 	interface Props {
@@ -98,3 +100,20 @@
 		{/if}
 	</div>
 </header>
+
+{#if audioStore.safeMode}
+	<div
+		transition:slide={{ duration: 150 }}
+		class="relative z-40 flex w-full items-center justify-between border-b border-amber-500/20 bg-amber-500/10 px-4 py-1.5 text-xs text-amber-600 dark:text-amber-400">
+		<div class="flex items-center gap-2">
+			<span class="rounded bg-amber-500/20 px-1.5 py-0.5 font-bold uppercase tracking-wider text-[10px]">Safe Mode</span>
+			<span>Auto-starting audio pipeline was skipped because Splitwave crashed last time.</span>
+		</div>
+		<button
+			type="button"
+			class="btn-warning px-3 py-0.5 text-xs"
+			onclick={() => (audioStore.safeMode = false)}>
+			Dismiss
+		</button>
+	</div>
+{/if}

--- a/src/lib/modules/audio/stores.svelte.ts
+++ b/src/lib/modules/audio/stores.svelte.ts
@@ -1,4 +1,5 @@
 import type { UnlistenFn } from '@tauri-apps/api/event';
+import { browser } from '$app/environment';
 import toast from 'svelte-french-toast';
 import { open, save } from '@tauri-apps/plugin-dialog';
 import { methods } from './methods';
@@ -8,6 +9,7 @@ import { pipelineStore } from '$lib/modules/pipeline/stores.svelte';
 import { isFromFuture } from '$lib/modules/pipeline/migrations';
 import type { FileRecordingNodeData, PipelineNode, RecordingFormat } from '$lib/modules/pipeline/types';
 import { appSettings } from '$lib/modules/settings/stores.svelte';
+import { errorStore } from '$lib/modules/error';
 
 // Mirrors `extension()` in the File Recording node: the dialog filter must
 // match the encoder the node will actually write.
@@ -37,6 +39,7 @@ class AudioStore {
 	pendingRetryPipelineId = $state<string | null>(null);
 	pendingNodeIds = $state<Set<string>>(new Set());
 	missingFilePaths = $state<Set<string>>(new Set());
+	safeMode = $state(false);
 
 	private lastGraph: StartPipelinePayload | null = null;
 	private fullGraph: StartPipelinePayload | null = null;
@@ -189,6 +192,7 @@ class AudioStore {
 	}
 
 	async activatePipeline(pipelineId: string, graph: StartPipelinePayload): Promise<void> {
+		this.safeMode = false;
 		this.lastGraph = graph;
 		this.fullGraph = graph;
 		const excluded = appSettings.keepRunningOnDisconnect ? await this.unresolvedInputIds(graph) : new Set<string>();
@@ -292,6 +296,16 @@ class AudioStore {
 	 * is left out of the initial start and reconnected later by the polling
 	 * loop once it becomes available. */
 	async autoActivateOnLaunch(): Promise<void> {
+		const crashGuard = browser && window.localStorage.getItem('splitwave:boot_audio_crash_guard') === 'true';
+		if (errorStore.hadPreviousCrash || crashGuard) {
+			this.safeMode = true;
+			if (browser) window.localStorage.removeItem('splitwave:boot_audio_crash_guard');
+			this.reportError(
+				new Error('Safe Mode: Auto-starting previous pipeline was skipped because Splitwave crashed last time.')
+			);
+			return;
+		}
+
 		const id = await pipelineMethods.getActivePipelineId().catch(() => null);
 		if (!id) return;
 		const p = await pipelineMethods.get(id).catch(() => null);
@@ -301,12 +315,17 @@ class AudioStore {
 		const excluded = appSettings.keepRunningOnDisconnect ? await this.unresolvedInputIds(full) : new Set<string>();
 		this.pendingNodeIds = excluded;
 		const reduced = this.buildReducedGraph(full, excluded);
+		if (browser) window.localStorage.setItem('splitwave:boot_audio_crash_guard', 'true');
 		try {
 			await methods.startPipeline(reduced);
 		} catch (e) {
+			if (browser) window.localStorage.removeItem('splitwave:boot_audio_crash_guard');
 			this.reportError(e);
 			return;
 		}
+		setTimeout(() => {
+			if (browser) window.localStorage.removeItem('splitwave:boot_audio_crash_guard');
+		}, 4000);
 		this.lastGraph = reduced;
 		this.runningPipelineId = id;
 		if (excluded.size > 0) {

--- a/src/lib/modules/debug/ui/debug_panel.svelte
+++ b/src/lib/modules/debug/ui/debug_panel.svelte
@@ -3,6 +3,7 @@
 	import { invoke } from '@tauri-apps/api/core';
 	import type { Update } from '@tauri-apps/plugin-updater';
 	import { errorStore } from '$lib/modules/error';
+	import { audioStore } from '$lib/modules/audio/stores.svelte';
 	import { updaterStore, latestRelease } from '$lib/modules/updater';
 	import { getCachedAppInfo } from '$lib/modules/app_info';
 	import { Menu, MenuItem, MenuSection, MenuSeparator } from '$lib/modules/overlay/ui';
@@ -50,6 +51,21 @@
 		});
 	}
 
+	async function fakeSafeMode() {
+		if (audioStore.isRunning) {
+			await audioStore.deactivatePipeline().catch(() => {});
+		}
+		audioStore.safeMode = true;
+		errorStore.report({
+			source: 'nativeCrash',
+			message: 'Native crash: SIGSEGV (Process crashed during audio startup)',
+			stack: 'The process terminated before a Rust backtrace could be captured. Use the OS crash dump for the native stack.',
+			thread: '<native>',
+			at: Date.now(),
+			previousRun: true
+		});
+	}
+
 	// Uses the real latest GitHub release so the modal shows notes of the shape
 	// users actually get.
 	async function fakeUpdateAvailable() {
@@ -67,6 +83,24 @@
 			phase: 'available',
 			update: stub,
 			notes: release?.notes ?? 'Could not reach the GitHub releases API.'
+		};
+	}
+
+	async function fakeBetaUpdateAvailable() {
+		const release = await latestRelease();
+		const stub = {
+			version: '1.2.0-rc.1',
+			currentVersion: getCachedAppInfo()?.appVersion ?? '1.1.0',
+			date: new Date().toISOString(),
+			downloadAndInstall: async () => {},
+			download: async () => {},
+			install: async () => {},
+			close: async () => {}
+		} as unknown as Update;
+		updaterStore.state = {
+			phase: 'available',
+			update: stub,
+			notes: release?.notes ?? '### Pre-release v1.2.0-rc.1\n\n- Safe mode on crash\n- Automatic pipeline backup\n- Pre-release beta channel'
 		};
 	}
 
@@ -95,14 +129,16 @@
 		<div transition:fly={{ duration: 200, y: 5 }}>
 			<Menu>
 				<MenuSection label="Errors" />
-				<MenuItem label="Rust panic" onclick={fakeRustPanic} />
+				<MenuItem label="Rust panic (preview)" onclick={fakeRustPanic} />
 				<MenuItem label="Real crash (panic)" onclick={realRustCrash} />
 				<MenuItem label="Native crash (process)" onclick={nativeCrash} />
 				<MenuItem label="Unexpected exit (process)" onclick={unexpectedExit} />
 				<MenuItem label="JS error" onclick={fakeJsError} />
 				<MenuItem label="Promise rejection" onclick={fakePromiseRejection} />
+				<MenuItem label="Safe Mode (simulate)" onclick={fakeSafeMode} />
 				<MenuSection label="Updater" />
 				<MenuItem label="Update available" onclick={fakeUpdateAvailable} />
+				<MenuItem label="Pre-release update available" onclick={fakeBetaUpdateAvailable} />
 				<MenuItem label="Downloading 30%" onclick={fakeDownloading} />
 				<MenuItem label="Update error" onclick={fakeUpdateError} />
 				<MenuSeparator />

--- a/src/lib/modules/error/init.ts
+++ b/src/lib/modules/error/init.ts
@@ -32,20 +32,19 @@ export async function installErrorHandlers(): Promise<void> {
 
 	// Fatal native failures cannot reach the live webview; replay every report
 	// persisted by the backend during the previous run.
-	invoke<CrashPayload[]>('take_crash_reports')
-		.then((reports) => {
-			for (const r of reports) {
-				errorStore.report({
-					source: r.kind ?? 'rustPanic',
-					message: r.message,
-					stack: r.backtrace,
-					thread: r.thread,
-					at: r.ts ?? Date.now(),
-					previousRun: true
-				});
-			}
-		})
-		.catch(() => {});
+	try {
+		const reports = await invoke<CrashPayload[]>('take_crash_reports');
+		for (const r of reports) {
+			errorStore.report({
+				source: r.kind ?? 'rustPanic',
+				message: r.message,
+				stack: r.backtrace,
+				thread: r.thread,
+				at: r.ts ?? Date.now(),
+				previousRun: true
+			});
+		}
+	} catch {}
 
 	window.addEventListener('error', (e) => {
 		errorStore.report({

--- a/src/lib/modules/error/stores.svelte.ts
+++ b/src/lib/modules/error/stores.svelte.ts
@@ -12,8 +12,12 @@ export interface ErrorEntry {
 
 class ErrorStore {
 	current = $state<ErrorEntry | null>(null);
+	hadPreviousCrash = $state(false);
 
 	report(entry: ErrorEntry): void {
+		if (entry.previousRun) {
+			this.hadPreviousCrash = true;
+		}
 		this.current = entry;
 	}
 

--- a/src/lib/modules/error/ui/error_modal.svelte
+++ b/src/lib/modules/error/ui/error_modal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { openUrl } from '@tauri-apps/plugin-opener';
 	import { errorStore } from '../stores.svelte';
+	import { audioStore } from '$lib/modules/audio/stores.svelte';
 	import { formatAppInfo, getCachedAppInfo } from '$lib/modules/app_info';
 	import { ModalShell } from '$lib/modules/overlay/ui/modal';
 	import CopyButton from '$lib/components/copy_button.svelte';
@@ -81,12 +82,27 @@
 		titleClass={current.previousRun ? 'text-sm font-semibold text-amber-500' : 'text-sm font-semibold text-red-500'}
 		onClose={dismiss}>
 		{#snippet badge()}
-			<span class="rounded-md bg-neutral-200 px-2 py-0.5 font-mono text-[10px] text-neutral-1000">
-				{sourceLabel(current.source)}
-			</span>
+			<div class="flex items-center gap-1.5">
+				<span class="rounded-md bg-neutral-200 px-2 py-0.5 font-mono text-[10px] text-neutral-1000">
+					{sourceLabel(current.source)}
+				</span>
+				{#if current.previousRun || audioStore.safeMode}
+					<span class="rounded-md bg-amber-500/20 px-1.5 py-0.5 font-sans text-[10px] font-semibold text-amber-600 dark:text-amber-400">
+						SAFE MODE
+					</span>
+				{/if}
+			</div>
 		{/snippet}
 
 		<div class="flex flex-col gap-3 px-5 py-4">
+			{#if current.previousRun || audioStore.safeMode}
+				<div class="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-600 dark:text-amber-400">
+					<div class="font-semibold">Safe Mode is active</div>
+					<div class="mt-0.5 text-[11px] opacity-90">
+						Automatic audio pipeline startup was skipped to prevent a crash loop. You can safely inspect or edit your pipelines and start them manually when ready.
+					</div>
+				</div>
+			{/if}
 			<p class="text-xs text-neutral-900">
 				{#if current.previousRun}
 					The app closed unexpectedly during your previous session. Reporting this helps us fix it.

--- a/src/lib/modules/pipeline/methods.ts
+++ b/src/lib/modules/pipeline/methods.ts
@@ -35,7 +35,18 @@ export const methods = {
 
 	async save(p: Pipeline): Promise<void> {
 		const clean = pruneDanglingEdges(p);
-		await store.set(KEY_PREFIX + p.id, { ...clean, version: PIPELINE_VERSION });
+		const nodes = clean.nodes.map((n) => {
+			if (n.kind !== 'fileRecording') return n;
+			const data = n.data as Record<string, unknown>;
+			return {
+				...n,
+				data: {
+					...data,
+					allowOverwrite: data.mode === 'overwrite'
+				}
+			};
+		});
+		await store.set(KEY_PREFIX + p.id, { ...clean, nodes, version: PIPELINE_VERSION });
 		await store.save();
 	},
 

--- a/src/lib/modules/pipeline/migrations/v2_file_recording_mode.ts
+++ b/src/lib/modules/pipeline/migrations/v2_file_recording_mode.ts
@@ -10,7 +10,7 @@ export function migrateFileRecordingMode(pipeline: Pipeline): Pipeline {
 			if (n.kind !== 'fileRecording') return n;
 			const data = withDefaults(n.kind, n.data) as Record<string, unknown>;
 			if (data.allowOverwrite === true) data.mode = 'overwrite';
-			delete data.allowOverwrite;
+			data.allowOverwrite = data.mode === 'overwrite';
 			return { ...n, data };
 		})
 	};

--- a/src/lib/modules/settings/stores.svelte.ts
+++ b/src/lib/modules/settings/stores.svelte.ts
@@ -5,6 +5,7 @@ const KEY = 'app:settings';
 
 interface Stored {
 	checkUpdatesOnLaunch: boolean;
+	includePreReleases: boolean;
 	maxSnapshots: number;
 	snapToGrid: boolean;
 	gridSize: number;
@@ -16,6 +17,7 @@ interface Stored {
 
 const DEFAULTS: Stored = {
 	checkUpdatesOnLaunch: true,
+	includePreReleases: false,
 	maxSnapshots: 20,
 	snapToGrid: false,
 	gridSize: 20,
@@ -41,6 +43,7 @@ function load(): Stored {
 class AppSettings {
 	#initial = load();
 	checkUpdatesOnLaunch = $state(this.#initial.checkUpdatesOnLaunch);
+	includePreReleases = $state(this.#initial.includePreReleases ?? false);
 	maxSnapshots = $state(this.#initial.maxSnapshots);
 	snapToGrid = $state(this.#initial.snapToGrid);
 	gridSize = $state(this.#initial.gridSize);
@@ -53,6 +56,7 @@ class AppSettings {
 		if (!browser) return;
 		const {
 			checkUpdatesOnLaunch,
+			includePreReleases,
 			maxSnapshots,
 			snapToGrid,
 			gridSize,
@@ -65,6 +69,7 @@ class AppSettings {
 			KEY,
 			JSON.stringify({
 				checkUpdatesOnLaunch,
+				includePreReleases,
 				maxSnapshots,
 				snapToGrid,
 				gridSize,

--- a/src/lib/modules/updater/methods.ts
+++ b/src/lib/modules/updater/methods.ts
@@ -4,6 +4,7 @@ import { LazyStore } from '@tauri-apps/plugin-store';
 import { invoke } from '@tauri-apps/api/core';
 import { arch, type as osType } from '@tauri-apps/plugin-os';
 import { updaterStore } from './stores.svelte';
+import { appSettings } from '$lib/modules/settings/stores.svelte';
 
 // Shape returned by the `check_for_updates` command; mirrors the plugin's
 // `check` metadata so `new Update(...)` can wrap it unchanged.
@@ -53,10 +54,35 @@ function noBuildMessage(): string {
 	return `Unfortunately, the latest version has no build for ${arch()} on ${osLabel(osType())}. It looks like you built it yourself, or this platform is no longer supported.`;
 }
 
+async function resolveUpdateEndpoint(): Promise<string | null> {
+	if (!appSettings.includePreReleases) return null;
+	try {
+		const res = await fetch(RELEASES_API, {
+			headers: { Accept: 'application/vnd.github+json' }
+		});
+		if (!res.ok) return null;
+		const releases = await res.json();
+		if (!Array.isArray(releases)) return null;
+		const candidate = releases.find(
+			(r: { draft?: boolean; assets?: Array<{ name: string; browser_download_url: string }> }) =>
+				!r.draft && Array.isArray(r.assets) && r.assets.some((a) => a.name === 'latest.json')
+		);
+		if (candidate) {
+			const asset = candidate.assets.find((a: { name: string }) => a.name === 'latest.json');
+			return asset?.browser_download_url ?? null;
+		}
+	} catch {
+		// Fall back to default endpoint
+	}
+	return null;
+}
+
 export async function checkForUpdates(silent = false): Promise<void> {
 	updaterStore.state = { phase: 'checking' };
+	let endpoint: string | null = null;
 	try {
-		const metadata = await invoke<CheckMetadata | null>('check_for_updates');
+		endpoint = await resolveUpdateEndpoint();
+		const metadata = await invoke<CheckMetadata | null>('check_for_updates', { endpoint });
 		const update = metadata ? new Update(metadata) : null;
 		if (!update) {
 			updaterStore.state = silent ? { phase: 'idle' } : { phase: 'up_to_date' };
@@ -77,7 +103,7 @@ export async function checkForUpdates(silent = false): Promise<void> {
 			updaterStore.state = silent ? { phase: 'idle' } : { phase: 'unsupported', message: noBuildMessage() };
 			return;
 		}
-		const message = await diagnoseError(e);
+		const message = await diagnoseError(e, endpoint);
 		updaterStore.state = silent ? { phase: 'idle' } : { phase: 'error', message };
 	}
 }
@@ -115,10 +141,10 @@ export function latestRelease(): Promise<Release | null> {
 	return fetchRelease('/latest');
 }
 
-async function diagnoseError(e: unknown): Promise<string> {
+async function diagnoseError(e: unknown, endpoint?: string | null): Promise<string> {
 	const base = e instanceof Error ? e.message : String(e);
 	try {
-		const detail = await invoke<string>('diagnose_update_error');
+		const detail = await invoke<string>('diagnose_update_error', { endpoint: endpoint ?? null });
 		return detail ? `${base}\n\n${detail}` : base;
 	} catch {
 		return base;

--- a/src/lib/modules/updater/ui/update_banner.svelte
+++ b/src/lib/modules/updater/ui/update_banner.svelte
@@ -48,7 +48,7 @@
 					</span>
 					{#if /-(rc|beta|alpha)/i.test(s.update.version)}
 						<span class="rounded-md bg-amber-500/20 px-1.5 py-0.5 font-sans text-[10px] font-semibold text-amber-600 dark:text-amber-400">
-							BETA
+							PRE-RELEASE
 						</span>
 					{/if}
 				</div>

--- a/src/lib/modules/updater/ui/update_banner.svelte
+++ b/src/lib/modules/updater/ui/update_banner.svelte
@@ -42,9 +42,16 @@
 	<ModalShell {title} {titleClass} canClose={s.phase !== 'installing'} onClose={dismiss}>
 		{#snippet badge()}
 			{#if s.phase === 'available' || s.phase === 'downloading'}
-				<span class="rounded-md bg-neutral-200 px-2 py-0.5 font-mono text-[10px] text-neutral-1000">
-					v{s.update.version}
-				</span>
+				<div class="flex items-center gap-1.5">
+					<span class="rounded-md bg-neutral-200 px-2 py-0.5 font-mono text-[10px] text-neutral-1000">
+						v{s.update.version}
+					</span>
+					{#if /-(rc|beta|alpha)/i.test(s.update.version)}
+						<span class="rounded-md bg-amber-500/20 px-1.5 py-0.5 font-sans text-[10px] font-semibold text-amber-600 dark:text-amber-400">
+							BETA
+						</span>
+					{/if}
+				</div>
 			{/if}
 		{/snippet}
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -96,15 +96,15 @@
 		logStore.open = !logStore.open;
 	}
 
-	onMount(() => {
+	onMount(async () => {
 		logStore.installConsoleCapture();
 		window.addEventListener('keydown', onLogsHotkey);
-		installErrorHandlers().catch(() => {});
+		await installErrorHandlers().catch(() => {});
 		loadAppInfo().catch(() => {});
-		audioStore
-			.init()
-			.then(() => audioStore.autoActivateOnLaunch())
-			.catch(() => {});
+		try {
+			await audioStore.init();
+			await audioStore.autoActivateOnLaunch();
+		} catch {}
 		pipelineStore.refresh().catch(() => {});
 		if (appSettings.checkUpdatesOnLaunch) checkForUpdates(true).catch(() => {});
 		listen<string>('menu://action', (e) => handleMenu(e.payload))
@@ -131,7 +131,7 @@
 
 <UpdateBanner />
 
-<main>
+<main class="flex h-screen flex-col overflow-hidden">
 	{@render children()}
 </main>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -75,7 +75,7 @@
 	{/snippet}
 </Header>
 
-<div class="flex h-[calc(100vh-40px)] flex-col gap-8 overflow-y-auto p-8">
+<div class="flex flex-1 min-h-0 flex-col gap-8 overflow-y-auto p-8">
 	{#if !isWindows}
 		<DriverUpdateBanner />
 	{/if}

--- a/src/routes/pipelines/[id]/+page.svelte
+++ b/src/routes/pipelines/[id]/+page.svelte
@@ -116,7 +116,7 @@
 	{/snippet}
 </Header>
 
-<div class="flex h-[calc(100vh-40px)] w-full">
+<div class="flex flex-1 min-h-0 w-full">
 	{#if notFound}
 		<div class="p-8 text-sm text-gray-500">Pipeline not found.</div>
 	{:else if stale}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -46,6 +46,7 @@
 	function setApp<
 		K extends
 			| 'checkUpdatesOnLaunch'
+			| 'includePreReleases'
 			| 'maxSnapshots'
 			| 'snapToGrid'
 			| 'gridSize'
@@ -209,6 +210,12 @@
 				label="Check on launch"
 				hint="Looks for a new version each time the app starts."
 				onChange={() => setApp('checkUpdatesOnLaunch', !appSettings.checkUpdatesOnLaunch)} />
+
+			<Toggle
+				checked={appSettings.includePreReleases}
+				label="Receive pre-release updates (Beta / RC)"
+				hint="Download preview versions (beta, RC, alpha) with the newest features and bug fixes before general release."
+				onChange={() => setApp('includePreReleases', !appSettings.includePreReleases)} />
 		</section>
 
 		<section class="flex flex-col gap-2">

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -83,7 +83,7 @@
 	{/snippet}
 </Header>
 
-<div class="h-[calc(100vh-40px)] overflow-y-auto p-8">
+<div class="flex-1 min-h-0 overflow-y-auto p-8">
 	<div class="flex max-w-2xl flex-col gap-8">
 		<section class="flex flex-col gap-3">
 			<div>

--- a/src/routes/virtual-devices/+page.svelte
+++ b/src/routes/virtual-devices/+page.svelte
@@ -119,7 +119,7 @@
 	{/snippet}
 </Header>
 
-<div class="flex h-[calc(100vh-40px)] flex-col gap-8 overflow-y-auto p-8">
+<div class="flex flex-1 min-h-0 flex-col gap-8 overflow-y-auto p-8">
 	<div class="mt-2 flex flex-col gap-1">
 		<h1 class="text-2xl font-semibold">Virtual Devices</h1>
 

--- a/src/routes/wiki/+page.svelte
+++ b/src/routes/wiki/+page.svelte
@@ -32,7 +32,7 @@
 	{/snippet}
 </Header>
 
-<div class="h-[calc(100vh-40px)] overflow-y-auto p-8">
+<div class="flex-1 min-h-0 overflow-y-auto p-8">
 	<div class="flex max-w-2xl flex-col gap-8">
 		{#each ENTRIES as entry (entry.title)}
 			<section class="flex flex-col gap-3">


### PR DESCRIPTION
## What does this PR do?

Prepares Splitwave for v1.2.0 testing and public release with rollback safety, crash protection, and an opt-in pre-release update channel:

1. **Pre-release Update Channel (Settings -> Updates)**:
   - Adds "Receive pre-release updates (Beta / RC)" toggle in Settings.
   - When enabled, the in-app updater resolves the latest pre-release endpoint (`-rc`, `-beta`, `-alpha`) from the GitHub Releases API instead of only stable releases.
   - Displays a distinct `PRE-RELEASE` badge on the update dialog when targeting pre-release builds.
   - Automatically marks releases as `prerelease` in GitHub Actions if the git tag contains `-rc`, `-beta`, or `-alpha`.

2. **Automatic Pre-1.2.0 Pipeline Backup & Downgrade Safety**:
   - Rust backend automatically snapshots `pipelines.json` to `pipelines.backup-v1.json` on app startup if the backup does not already exist.
   - Preserves backward compatibility for `fileRecording` nodes by syncing `allowOverwrite = (mode === 'overwrite')` on save and during migrations, allowing seamless rollback to v1.1.0 without losing overwrite intent.

3. **Safe Mode Crash Loop Protection**:
   - Sequences error handler initialization (`take_crash_reports`) before audio pipeline auto-activation on startup.
   - If the previous run ended in a crash or audio boot failure, `audioStore.autoActivateOnLaunch()` skips auto-starting the pipeline to prevent boot crash loops.
   - Displays an amber Safe Mode alert banner situated directly beneath the header
   - Error modal displays a prominent `SAFE MODE` indicator explaining that auto-start was disabled.

4. **Dev Tools**:
   - Added triggers to test "Safe Mode (simulate)" and "Pre-release update available" alongside existing debug options.

---

## Why is this the right approach?

- **Pre-release channel**: Allows testing v1.2.0-rc builds with early testers directly through the updater without forcing manual GitHub asset downloads or affecting stable users.
- **Automatic backup**: Backing up `pipelines.json` in Rust at startup before any frontend JavaScript or migration code runs guarantees preset preservation even if an unexpected edge case fails during initial load.
- **Safe Mode**: Startup crash loops (e.g., from unplugged hardware or crashing audio drivers) are prevented without clearing the user's saved pipeline configuration.

---

## Checklist

- [x] Diff is limited to the change — no unrelated edits
- [x] `bun run check` passes (0 errors)
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` passes
- [x] Generated TS types are committed with the Rust change (if any)
- [x] No RT audio path violations (no allocations, locks, or syscalls in audio callbacks or DSP worker)

---

## Platform coverage

- Developed on: macOS
- Tested on: macOS 14, Fedora 44, Windows 11
- What I did to test:
  - Verified pre-release updater endpoint resolution and `PRE-RELEASE` modal badge.
  - Verified automatic backup creation of `pipelines.backup-v1.json` in app data directory.
  - Verified downgrade compatibility with `fileRecording` node mode/overwrite sync.
  - Tested Safe Mode recovery flow on native process crash / panic and simulated Safe Mode trigger.
  - Verified layout responsiveness across all routes (`+page`, `pipelines/[id]`, `settings`, `virtual-devices`, `wiki`).